### PR TITLE
Create dev environment

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "0.38.4",
+      "version": "1.0.0-rc0001",
       "commands": [
         "dotnet-cake"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+ARG VARIANT="3.1"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnetcore:0-${VARIANT}
+
+# Install .NET 5.0
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y apt-transport-https \
+    && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y dotnet-sdk-5.0
+
+# Install Mono (soon won't be necessary (.NET 6?))
+RUN apt install gnupg ca-certificates \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+    && echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && apt update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt install -y mono-devel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+    "name": "Dev (Ubuntu - .NET 5, 3.1 and Mono)",
+    "build": {
+        "dockerfile": "Dockerfile",
+    },
+
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+
+    "extensions": [
+        "ms-dotnettools.csharp",
+        "k--kato.docomment",
+        "shardulm94.trailing-spaces",
+        "cake-build.cake-vscode",
+        "streetsidesoftware.code-spell-checker",
+        "hediet.vscode-drawio",
+    ],
+
+    "remoteUser": "vscode",
+
+    // Required for Podman (Docker alternative)
+    // SELinux issues: https://github.com/containers/podman/issues/3683
+    "runArgs": [ "--security-opt", "label=disable" ],
+
+    // Podman issues: https://github.com/microsoft/vscode-remote-release/issues/3231
+    "containerEnv": {
+        "HOME": "/home/vscode"
+    }
+}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -79,7 +79,7 @@ jobs:
 
       # No need to stage as one job can create the binaries for all platforms
       - name: "Build and test"
-        run: dotnet cake --target=BuildTest --configuration=$BUILD_CONFIG --verbosity=diagnostic
+        run: dotnet cake --target=BuildTest --configuration=${{ env.BUILD_CONFIG }} --verbosity=diagnostic
 
   # Preview release on push to develop only
   preview:
@@ -108,7 +108,7 @@ jobs:
         run: wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
 
       - name: "Publish NuGet to preview feed"
-        run: dotnet nuget push -s $PREVIEW_NUGET_FEED -k az ./artifacts/*.nupkg
+        run: dotnet nuget push -s $PREVIEW_NUGET_FEED -k az --skip-duplicate ./artifacts/*.nupkg
         env:
           VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.NUGET_PREVIEW_TOKEN }}"}]}'
 


### PR DESCRIPTION
Provide a dev environment via containers (tested with Podman in Fedora 32).
It's integrated with the VS Code remote container extensions.

Based on the image for .NET Core 3.1, it installs .NET 5 and Mono 6.2.
Also, it installs C# recommended extensions for VS Code:
- C#
- C# XML Documentation Comments
- Cake
- Code Spell Checker
- Draw.io integration
- Trailing Spaces

Had to fix some weird issue in the build variables and make it more robust skipping duplicated nuget pushes on a rebuild.

Related PR: https://github.com/pleonex/PleOps.Cake/pull/17