### PR TITLE
Add code analyzers and bump to .NET 5

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,7 +11,7 @@ on:
     tags: [ "v*" ]
 
 env:
-  NET_SDK: '3.1.404'
+  NET_SDK: '5.0.100'
   BUILD_CONFIG: 'Release'
 
 jobs:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           dotnet-version: ${{ env.NET_SDK }}
 
+      # Some Cake tools has a dependency with .NET Core 3.1
+      - name: "Setup .NET Core 3.1 for dependencies"
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.404'
+
       - name: "Install build tools"
         run: |
           dotnet tool restore
@@ -73,6 +79,12 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
+
+      # Some Cake tools has a dependency with .NET Core 3.1
+      - name: "Setup .NET Core 3.1 for dependencies"
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.404'
 
       - name: "Install build tools"
         run: |

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,188 @@
+# Top-level config file
+root = true
+
+# Generic C# files
+[*.cs]
+
+## Generic options
+charset = utf-8-bom
+indent_size = 4
+indent_style = space
+tab_width = 8
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+
+## .NET style rules
+### Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+file_header_template = unset # too long to set here
+
+### this. and Me. qualifiers
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+
+### Language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+### Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_style_readonly_field = true:warning
+
+### Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
+
+### Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = true:warning
+dotnet_style_prefer_conditional_expression_over_return = true:warning
+dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
+dotnet_style_operator_placement_when_wrapping = end_of_line
+
+### Null-checking preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+
+### Unnecessary code rules
+dotnet_code_quality_unused_parameters = all:warning
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+## C# style rules
+### var preferences
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+### Expression-bodied members
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = when_on_single_line:warning
+csharp_style_expression_bodied_indexers = when_on_single_line:warning
+csharp_style_expression_bodied_accessors = when_on_single_line:warning
+csharp_style_expression_bodied_lambdas = when_on_single_line:warning
+csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
+
+### Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_switch_expression = true:warning
+csharp_style_prefer_pattern_matching = true:warning
+csharp_style_prefer_not_pattern = true:warning
+
+### Expression-level preferences
+csharp_style_inlined_variable_declaration = true:warning
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:warning
+csharp_style_unused_value_expression_statement_preference = discard_variable:warning
+
+### Null-checking preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+
+### Code-block preferences
+csharp_prefer_braces = when_multiline:error
+csharp_prefer_simple_using_statement = true:suggestion
+
+### 'using' directive preferences
+csharp_using_directive_placement = inside_namespace:warning
+
+### Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+
+## C# formatting rules
+### New line preferences
+csharp_new_line_before_open_brace = local_functions,methods,types:warning
+csharp_new_line_before_else = false:warning
+csharp_new_line_before_catch = false:warning
+csharp_new_line_before_finally = false:warning
+csharp_new_line_before_members_in_object_initializers = true:warning
+csharp_new_line_before_members_in_anonymous_types = true:warning
+csharp_new_line_between_query_expression_clauses = true:warning
+
+### Indentation preferences
+csharp_indent_case_contents = true:warning
+csharp_indent_switch_labels = true:warning
+csharp_indent_labels = one_less_than_current:warning
+csharp_indent_block_contents = true:warning
+csharp_indent_braces = false:warning
+csharp_indent_case_contents_when_block = false:warning
+
+### Spacing preferences
+csharp_space_after_cast = false:warning
+csharp_space_after_keywords_in_control_flow_statements = true:warning
+csharp_space_between_parentheses = false:warning
+csharp_space_before_colon_in_inheritance_clause = true:warning
+csharp_space_after_colon_in_inheritance_clause = true:warning
+csharp_space_around_binary_operators = before_and_after:warning
+csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:warning
+csharp_space_between_method_declaration_name_and_open_parenthesis = false:warning
+csharp_space_between_method_call_parameter_list_parentheses = false:warning
+csharp_space_between_method_call_empty_parameter_list_parentheses = false:warning
+csharp_space_between_method_call_name_and_opening_parenthesis = false:warning
+csharp_space_after_comma = true:warning
+csharp_space_before_comma = false:warning
+csharp_space_after_dot = false:warning
+csharp_space_before_dot = false:warning
+csharp_space_after_semicolon_in_for_statement = true:warning
+csharp_space_before_semicolon_in_for_statement = false:warning
+csharp_space_around_declaration_statements = false:warning
+csharp_space_before_open_square_brackets = false:warning
+csharp_space_between_empty_square_brackets = false:warning
+csharp_space_between_square_brackets = false:warning
+
+### Wrapping preferences
+csharp_preserve_single_line_statements = false:warning
+csharp_preserve_single_line_blocks = true
+
+## Naming styles rules
+dotnet_diagnostic.IDE1006.severity = warning
+
+## Code analyzers
+### .NET SDK
+dotnet_diagnostic.CA1303.severity = none # We don't translate exception and log messages from English
+
+### StyleCop
+dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
+dotnet_diagnostic.SA1500.severity = none # Allow inline braces
+dotnet_diagnostic.SA1503.severity = suggestion # Braces can be omitted (guards can)
+dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
+
+### SonarAnalyzer
+dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
+
+# Special rules for test projects
+[MyTests/*.cs]
+dotnet_diagnostic.CS1591.severity = none # Disable documentation
+dotnet_diagnostic.CA1001.severity = none # No need to implement IDisposable in test classes with cleanup.
+dotnet_diagnostic.CA1034.severity = none # Public types in test classes for testing implementations
+dotnet_diagnostic.CA1040.severity = none # Empty interfaces for testing
+dotnet_diagnostic.CA1062.severity = none # No need to validate args in test methods
+dotnet_diagnostic.CA1305.severity = none # No culture method for quick test code
+dotnet_diagnostic.CA1307.severity = none # No culture method for quick test code
+dotnet_diagnostic.SA0001.severity = none # Disable documentation
+dotnet_diagnostic.SA1600.severity = none # Disable documentation
+dotnet_diagnostic.S2699.severity = none # Assert may be in helper methods
+dotnet_diagnostic.S3966.severity = none # Dispose twice to test implementation

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,24 +10,35 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/pleonex/template-csharp</PackageProjectUrl>
         <RepositoryUrl>https://github.com/pleonex/template-csharp</RepositoryUrl>
-        <PackageReleaseNotes>TODO</PackageReleaseNotes>
         <PackageIcon>icon.png</PackageIcon>
         <PackageTags>net;csharp;devops;pipeline;github</PackageTags>
+    </PropertyGroup>
 
+    <!-- Deterministic and source link -->
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
         <!-- Deterministic and source link -->
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
 
-    <!-- Deterministic and source link -->
-    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    </ItemGroup>
+
+    <!-- Code analyzers -->
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.14.0.22654" PrivateAssets="All"/>
+        <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All"/>
     </ItemGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,18 +3,8 @@
     <ItemGroup>
         <PackageReference Update="Yarhl" Version="3.0.0" />
         <PackageReference Update="nunit" Version="3.12.0" />
-        <PackageReference Update="NUnit3TestAdapter" Version="3.16.1" />
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.6.1"/>
+        <PackageReference Update="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.0"/>
         <PackageReference Update="coverlet.collector" Version="1.3.0" />
     </ItemGroup>
-
-    <!-- Generate helper file for code coverage when using source link -->
-    <Target Name="CoverletGetPathMap"
-            DependsOnTargets="InitializeSourceRootMappedPaths"
-            Returns="@(_LocalTopLevelSourceRoot)"
-            Condition="'$(DeterministicSourcePaths)' == 'true'">
-        <ItemGroup>
-            <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
-        </ItemGroup>
-    </Target>
 </Project>

--- a/src/MyConsole/MyConsole.csproj
+++ b/src/MyConsole/MyConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <SelfContained>false</SelfContained>
   </PropertyGroup>

--- a/src/MyConsole/MyConsole.csproj
+++ b/src/MyConsole/MyConsole.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 

--- a/src/MyConsole/Program.cs
+++ b/src/MyConsole/Program.cs
@@ -1,10 +1,36 @@
-﻿using System;
-
+﻿// Copyright (c) 2020 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 namespace MyConsole
 {
-    class Program
+    using System;
+
+    /// <summary>
+    /// Main program class.
+    /// </summary>
+    public static class Program
     {
-        static void Main(string[] args)
+        /// <summary>
+        /// Main entry-point.
+        /// </summary>
+        /// <param name="args">Application arguments.</param>
+        public static void Main(string[] args)
         {
             string consoleVersion = typeof(Program).Assembly.GetName().Version.ToString();
             Console.WriteLine($"Console version: {consoleVersion}");

--- a/src/MyLibrary/LibVersion.cs
+++ b/src/MyLibrary/LibVersion.cs
@@ -1,9 +1,35 @@
-﻿namespace MyLibrary
+﻿// Copyright (c) 2020 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace MyLibrary
 {
     using System.Reflection;
 
+    /// <summary>
+    /// Version of the library.
+    /// </summary>
     public static class LibVersion
     {
+        /// <summary>
+        /// Gets the version of the library.
+        /// </summary>
+        /// <returns>The version of the library.</returns>
         public static string GetVersion()
         {
             Assembly library = typeof(LibVersion).Assembly;

--- a/src/MyLibrary/MyLibrary.csproj
+++ b/src/MyLibrary/MyLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MyTests/MyTests.csproj
+++ b/src/MyTests/MyTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MyTests/VersionTests.cs
+++ b/src/MyTests/VersionTests.cs
@@ -1,9 +1,28 @@
+// Copyright (c) 2020 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 namespace MyTests
 {
-    using NUnit.Framework;
     using MyLibrary;
+    using NUnit.Framework;
 
-    public class Tests
+    public class VersionTests
     {
         [Test]
         public void TestVersionNotNull()


### PR DESCRIPTION
Add new code analyzers and create `.editorconfig` with C# code conventions. Bump projects to .NET 5 to take advantage of latest code analyzers and improvements.

Reference issue: https://github.com/pleonex/PleOps.Cake/issues/2