### PR TITLE
Update README with setup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This project showcases how to use the
 [PleOps.Cake](https://github.com/pleonex/PleOps.Cake) pipeline with an example
 .NET project.
 
+## Setup
+
+Follow the
+[checklist in PleOps.Cake](https://github.com/pleonex/PleOps.Cake/blob/develop/docs/guides/Project%20setup.md)
+to adapt this template to your project.
+
 ## Build
 
 Requirements:


### PR DESCRIPTION
Add a link to the project setup in the README.

Related issue: https://github.com/pleonex/PleOps.Cake/issues/4