### PR TITLE
Trigger pipeline on GitHub release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,6 +9,9 @@ on:
     branches: [ develop ]
     # Stable
     tags: [ "v*" ]
+  release:
+    types:
+      - published
 
 env:
   NET_SDK: '5.0.101'


### PR DESCRIPTION
It seems the tag push notification doesn't trigger on GitHub releases. Fixed by adding the release publication notification. Also add badges.