### PR TITLE
Add more VS Code task launches

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,9 +23,9 @@
 
     "remoteUser": "vscode",
 
-    // Required for Podman (Docker alternative)
+    // PODMAN ONLY. You may need to remove this line for Docker.
     // SELinux issues: https://github.com/containers/podman/issues/3683
-    "runArgs": [ "--security-opt", "label=disable" ],
+    "runArgs": [ "--security-opt", "label=disable", "--userns=keep-id" ],
 
     // Podman issues: https://github.com/microsoft/vscode-remote-release/issues/3231
     "containerEnv": {

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -36,9 +36,7 @@ jobs:
           dotnet-version: '3.1.404'
 
       - name: "Install build tools"
-        run: |
-          dotnet tool restore
-          dotnet cake --bootstrap
+        run: dotnet tool restore
 
       - name: "Generate release notes"
         run: dotnet cake --target=Generate-ReleaseNotes --verbosity=diagnostic
@@ -87,9 +85,7 @@ jobs:
           dotnet-version: '3.1.404'
 
       - name: "Install build tools"
-        run: |
-          dotnet tool restore
-          dotnet cake --bootstrap
+        run: dotnet tool restore
 
       # No need to stage as one job can create the binaries for all platforms
       - name: "Build and test"
@@ -127,9 +123,7 @@ jobs:
           dotnet-version: '3.1.404'
 
       - name: "Install build tools"
-        run: |
-          dotnet tool restore
-          dotnet cake --bootstrap
+        run: dotnet tool restore
 
       # Weird way to authenticate in Azure DevOps Artifacts
       # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": ".NET Launch (console)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Cake: Run Build",
@@ -14,6 +14,12 @@
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "internalConsole"
+        },
+        {
+            "name": ".NET Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,26 +1,63 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "cake",
-			"script": "Default",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"problemMatcher": [
-				"$msCompile"
-			],
-			"label": "Cake: Run Default"
-		},
-		{
-			"type": "cake",
-			"script": "Build",
-			"group": "build",
-			"problemMatcher": [
-				"$msCompile"
-			],
-			"label": "Cake: Run Build"
-		}
-	]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "cake"
+            ],
+            "group": "build",
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "label": "Cake: Run Default"
+        },
+        {
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "cake",
+                "--target=Build"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "label": "Cake: Run Build"
+        },
+        {
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "cake",
+                "--target=BuildTest"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "label": "Cake: Run Test"
+        },
+        {
+            "type": "process",
+            "command": "dotnet",
+            "args": [
+                "cake",
+                "--target=Build",
+                "--configuration=Release"
+            ],
+            "group": "build",
+            "problemMatcher": [
+                "$msCompile"
+            ],
+            "label": "Cake: Run Build for release"
+        }
+    ]
 }


### PR DESCRIPTION
### Description

Add new task launch for VS Code:

- `Cake: Run Build`. Run the `Build` target that just build. This is the default build task (triggered via <kbd>Ctrl+Shift+B</kbd>)
- `Cake: Run Default`. Run the `Default` target that creates all the artifacts. This is another build task launch.
- `Cake: Run Test`. Run the `BuildTest` target that builds and run the tests. This is the default test task (no default keyboard shortcut but you can assign your own).
- `Cake: Run Build for Release`. Run the `Build` target for the `Release` configuration. This is useful to add as a dependency with performance tests that requires release builds.

Also add the attach .NET process useful for some application and test use cases.

Also remove an unnecessary step in the workflow as the Cake bootstrapping is done automatically and improve the Podman support adding a missing flag.