### PR TITLE
Set C# formatter and fix C# brace style configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
 
     "extensions": [
         "ms-dotnettools.csharp",
-        "k--kato.docomment",
         "shardulm94.trailing-spaces",
         "cake-build.cake-vscode",
         "streetsidesoftware.code-spell-checker",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "editor.rulers": [
+        80,
+        120
+    ],
+    "editor.renderWhitespace": "boundary",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[markdown]": {
+        "editor.formatOnSave": true,
+    },
+    "[csharp]": {
+        "editor.defaultFormatter": "ms-dotnettools.csharp",
+    },
+    "prettier.proseWrap": "always",
+}

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -113,7 +113,7 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 
 ## C# formatting rules
 ### New line preferences
-csharp_new_line_before_open_brace = local_functions,methods,types:warning
+csharp_new_line_before_open_brace = local_functions,methods,types
 csharp_new_line_before_else = false:warning
 csharp_new_line_before_catch = false:warning
 csharp_new_line_before_finally = false:warning


### PR DESCRIPTION
### Description

Add a VS Code setting file with recommended settings for Markdown and C#. It sets the C# formatter for C# language and the Prettier formatter for other languages. Remove the C# document plugin as it's deprecated and implemented in the C# plugin

The default VS Code settings are opinionated, remember to adapt to your preferences!

Also fix #12 by setting correctly the value in `.editorconfig`.

### Example

To use the formatter in VS Code in the current document press <kbd>Ctrl+Shift+P</kbd> and select the command `Format document` (default keyboard shortcut <kbd>Ctrl+Shift+I</kbd>).