### PR TITLE
Fix style rules in .editorconfig

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -114,12 +114,12 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 ## C# formatting rules
 ### New line preferences
 csharp_new_line_before_open_brace = local_functions,methods,types
-csharp_new_line_before_else = false:warning
-csharp_new_line_before_catch = false:warning
-csharp_new_line_before_finally = false:warning
-csharp_new_line_before_members_in_object_initializers = true:warning
-csharp_new_line_before_members_in_anonymous_types = true:warning
-csharp_new_line_between_query_expression_clauses = true:warning
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
 
 ### Indentation preferences
 csharp_indent_case_contents = true:warning
@@ -174,7 +174,7 @@ dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
 dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
 
 # Special rules for test projects
-[MyTests/*.cs]
+[*Tests/**]
 dotnet_diagnostic.CS1591.severity = none # Disable documentation
 dotnet_diagnostic.CA1001.severity = none # No need to implement IDisposable in test classes with cleanup.
 dotnet_diagnostic.CA1034.severity = none # Public types in test classes for testing implementations


### PR DESCRIPTION
### Description

Fix the syntax of some style rules in `.editorconfig`. Tested with Yarhl project.