### PR TITLE
Upgrade for Ubuntu 20.04 dev container

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0002",
+      "version": "1.1.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,19 +1,17 @@
-# TODO #35 Support Ubuntu 20.04
-FROM mcr.microsoft.com/vscode/devcontainers/dotnetcore:0.148.1-3.1
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:5.0
 
-# Install .NET 5.0
-RUN apt-get update \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y apt-transport-https \
-    && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+# Install .NET Core 3.1
+RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb \
     && apt-get update \
-    && apt-get install -y dotnet-sdk-5.0
+    && apt-get install -y apt-transport-https \
+    && apt-get update \
+    && apt-get install -y aspnetcore-runtime-3.1
 
 # Install Mono (soon won't be necessary (.NET 6?))
 RUN apt install gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.101'
+  NET_SDK: '5.0.201'
 
 jobs:
   build_main:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.404'
+          dotnet-version: '3.1.407'
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -82,7 +82,7 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.404'
+          dotnet-version: '3.1.407'
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -120,7 +120,7 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.404'
+          dotnet-version: '3.1.407'
 
       - name: "Install build tools"
         run: dotnet tool restore

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Check our on-line [documentation](https://www.pleonex.dev/PleOps.Cake/).
 
 ## Build
 
-The project requires to build .NET 5.0 SDK and .NET Core 3.1 runtime. If you
-open the project with VS Code and you did install the
+The project requires to build .NET 5 SDK and .NET Core 3.1 runtime (Linux and
+MacOS require also Mono). If you open the project with VS Code and you did
+install the
 [VS Code Remote Containers](https://code.visualstudio.com/docs/remote/containers)
 extension, you can have an already pre-configured development environment with
 Docker or Podman.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,17 +1,17 @@
 <Project>
     <!-- Centralize dependency management -->
     <ItemGroup>
-        <PackageVersion Include="Yarhl" Version="3.0.0" />
+        <PackageVersion Include="Yarhl" Version="3.1.0" />
 
-        <PackageVersion Include="nunit" Version="3.12.0" />
+        <PackageVersion Include="nunit" Version="3.13.1" />
         <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3"/>
-        <PackageVersion Include="coverlet.collector" Version="1.3.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.1"/>
+        <PackageVersion Include="coverlet.collector" Version="3.0.3" />
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.15.0.24505" />
-        <PackageVersion Include="Roslynator.Analyzers" Version="3.0.0" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.19.0.28253" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="3.1.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description

PleOps.Cake now run under Ubuntu 20.04. Update the dev container image and GitHub workflow to the latest image and SDK.

Related to https://github.com/pleonex/PleOps.Cake/issues/35
