### PR TITLE
Bump the .NET SDK version in the CI

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,8 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.201'
+  NET_SDK: '5.0.301'
+  NET31_SDK: '3.1.410'
 
 jobs:
   build_main:
@@ -33,7 +34,7 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.407'
+          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -82,7 +83,7 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.407'
+          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -120,7 +121,7 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.407'
+          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore


### PR DESCRIPTION
### Description

Bump and improve the .NET SDK versioning in the GitHub Action CI. Also validate latest PleOps.Cake version.