### PR TITLE
Downgrade .NET SDK to fix build issues

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.301'
+  NET_SDK: '5.0.300'
   NET31_SDK: '3.1.410'
 
 jobs:


### PR DESCRIPTION
### Description

For some reason .NET 5.0.301 is causing issues with git in the GitHub Action CI. Downgrading to 300 seems to fix.