### PR TITLE
 Migrate branch name develop to main #51 

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     # Preview
-    branches: [ develop ]
+    branches: [ main ]
     # Stable
     tags: [ "v*" ]
   release:
@@ -92,11 +92,11 @@ jobs:
       - name: "Build and test"
         run: dotnet cake --target=BuildTest --configuration=Release --verbosity=diagnostic
 
-  # Preview release on push to develop only
+  # Preview release on push to main only
   # Stable release on version tag push only
   push_artifacts:
     name: "Push artifacts"
-    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     needs: [ "build_main", "build_sec" ]
     runs-on: ubuntu-latest
     env:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,6 @@
 mode: ContinuousDeployment
 branches:
-  develop:
+  master:
+    regex: ^main$
     tag: preview
     increment: Patch

--- a/docs/global_metadata.json
+++ b/docs/global_metadata.json
@@ -8,6 +8,6 @@
     "_gitContribute": {
         "apiSpecFolder": "docs/apidoc",
         "repo": "https://github.com/pleonex/template-csharp",
-        "branch": "develop"
+        "branch": "main"
     }
 }


### PR DESCRIPTION
### Description

The new convention of trunk development is to use the branch name `main`. Update configuration and docs to the new branch name.

Related PR: https://github.com/pleonex/PleOps.Cake/pull/51
