### PR TITLE
Upgrade to .NET 6 and add README in NuGet

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,9 @@
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:5.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
 
-# Install .NET Core 3.1
-RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y apt-transport-https \
-    && apt-get update \
-    && apt-get install -y aspnetcore-runtime-3.1
-
-# Install Mono (soon won't be necessary (.NET 6?))
-RUN apt install -y gnupg ca-certificates \
+# Install Mono (for DocFX)
+RUN apt install -y apt-transport-https dirmngr gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> tee /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
-    "name": "Dev (Ubuntu - .NET 5, 3.1 and Mono)",
+    "name": "Dev (.NET 6 and Mono)",
     "build": {
         "dockerfile": "Dockerfile",
-    },
-
-    "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
     },
 
     "extensions": [

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,8 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.402'
-  NET31_SDK: '3.1.414'
+  NET_SDK: '6.0.100'
 
 jobs:
   build_main:
@@ -31,10 +30,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -80,10 +75,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -118,10 +109,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.NET31_SDK }}
 
       - name: "Install build tools"
         run: dotnet tool restore

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Cake: Run Build",
-            "program": "${workspaceFolder}/src/MyConsole/bin/Debug/net5.0/MyConsole.dll",
+            "program": "${workspaceFolder}/src/MyConsole/bin/Debug/net6.0/MyConsole.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ Check our on-line [documentation](https://www.pleonex.dev/PleOps.Cake/).
 
 ## Build
 
-The project requires to build .NET 5 SDK and .NET Core 3.1 runtime (Linux and
-MacOS require also Mono). If you open the project with VS Code and you did
-install the
+The project requires to build .NET 6.0 SDK (Linux and MacOS require also Mono).
+If you open the project with VS Code and you did install the
 [VS Code Remote Containers](https://code.visualstudio.com/docs/remote/containers)
 extension, you can have an already pre-configured development environment with
 Docker or Podman.

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -105,7 +105,7 @@ csharp_prefer_braces = when_multiline:error
 csharp_prefer_simple_using_statement = true:suggestion
 
 ### 'using' directive preferences
-csharp_using_directive_placement = inside_namespace:warning
+csharp_using_directive_placement = outside_namespace:warning
 
 ### Modifier preferences
 csharp_prefer_static_local_function = true:warning
@@ -166,6 +166,7 @@ dotnet_diagnostic.CA1303.severity = none # We don't translate exception and log 
 
 ### StyleCop
 dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
+dotnet_diagnostic.SA1200.severity = none # Using directives outside namespaces
 dotnet_diagnostic.SA1500.severity = none # Allow inline braces
 dotnet_diagnostic.SA1503.severity = suggestion # Braces can be omitted (guards can)
 dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,11 @@
         <Copyright>Copyright (C) 2020 Benito Palacios Sánchez</Copyright>
 
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+        <!-- Due to known issues, .NET 6 SDK may give a false warning
+             when packing apps if the SelfContained value is in the csproj
+             instead in the CLI command. -->
+        <NoWarn>NETSDK1179</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +19,7 @@
         <RepositoryUrl>https://github.com/pleonex/template-csharp</RepositoryUrl>
         <PackageIcon>icon.png</PackageIcon>
         <PackageTags>net;csharp;devops;pipeline;github</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <!-- Deterministic and source link -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,14 +4,14 @@
         <PackageVersion Include="Yarhl" Version="3.1.0" />
 
         <PackageVersion Include="nunit" Version="3.13.2" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="4.0.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
         <PackageVersion Include="coverlet.collector" Version="3.1.0" />
 
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.30.0.37606" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.32.0.39516" />
         <PackageVersion Include="Roslynator.Analyzers" Version="3.2.2" />
     </ItemGroup>
 </Project>

--- a/src/MyConsole/MyConsole.csproj
+++ b/src/MyConsole/MyConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>

--- a/src/MyConsole/Program.cs
+++ b/src/MyConsole/Program.cs
@@ -17,10 +17,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System;
+
 namespace MyConsole
 {
-    using System;
-
     /// <summary>
     /// Main program class.
     /// </summary>

--- a/src/MyLibrary/LibVersion.cs
+++ b/src/MyLibrary/LibVersion.cs
@@ -17,10 +17,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System.Reflection;
+
 namespace MyLibrary
 {
-    using System.Reflection;
-
     /// <summary>
     /// Version of the library.
     /// </summary>

--- a/src/MyLibrary/MyLibrary.csproj
+++ b/src/MyLibrary/MyLibrary.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="../../docs/images/logo_128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
+    <None Include="../../README.md" Pack="true" PackagePath="$(PackageReadmeFile)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyTests/MyTests.csproj
+++ b/src/MyTests/MyTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MyTests/VersionTests.cs
+++ b/src/MyTests/VersionTests.cs
@@ -17,11 +17,11 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using MyLibrary;
+using NUnit.Framework;
+
 namespace MyTests
 {
-    using MyLibrary;
-    using NUnit.Framework;
-
     public class VersionTests
     {
         [Test]


### PR DESCRIPTION
### Description

Update projects and CI to target .NET 6. Add a README inside the NuGet so it shows automatically in nuget.org.

.NET Core 3.1 is not required anymore for the CI. Also adjust code guideline to put usings outside namespaces.