### PR TITLE
:sparkles: Update build system for Cake v2.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.3.0",
+      "version": "2.1.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '6.0.100'
+  NET_SDK: '6.0.200'
 
 jobs:
   build_main:
@@ -37,7 +37,7 @@ jobs:
       - name: "Generate release notes"
         run: dotnet cake --target=Generate-ReleaseNotes --verbosity=diagnostic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: "Build, test and stage"
         run: dotnet cake --target=Stage-Artifacts --configuration=Release --verbosity=diagnostic
@@ -121,7 +121,7 @@ jobs:
       - name: "Publish artifacts"
         run: dotnet cake --target=Push-Artifacts --verbosity=diagnostic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           STABLE_NUGET_FEED_TOKEN: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
           PREVIEW_NUGET_FEED_TOKEN: "az"  # Dummy, auth via below env var
           VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.NUGET_PREVIEW_TOKEN }}"}]}'

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -4,7 +4,7 @@
         "src": [
           {
             "files": [
-              "MyLibrary/MyLibrary.csproj"
+              "MyLibrary/bin/**/MyLibrary.dll"
             ],
             "src": "../src"
           }


### PR DESCRIPTION
### Description

Upgrade the build system to the latest version of PleOps.Cake using Cake 2.1.
Also apply fixes for documentation and release notes.

### Migration steps

- Update `dotnet-cake` to `2.1` in _.config/dotnet-tools.json_
- Fix API docs for .NET 6 projects:
  - Replace the `.csproj` reference in _docs/docfx.json_ with the DLLs. For instance, use: `"MyLibrary/bin/**/MyLibrary.dll"` 
- Fix tokens for release notes (it seems a temporary issue in GitHub):
  1. Create a custom token with the `repo` permissions.
  2. Add the token to the secrets repository/organization variables 
  3. Replace `secrets.GITHUB_TOKEN` with `secrets.<VAR_NAME>` in _.github/workflows/build-and-release.yml_