### PR TITLE
:arrow_up: Update to PleOps.Cake 0.8.0 (Cake 3.0)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.2.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0-jammy
 
 # Install Mono (for DocFX)
 RUN apt install -y apt-transport-https dirmngr gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" >> /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
-    && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel
+
+# Bug in the installation of .NET 6 in ubuntu https://github.com/dotnet/runtime/issues/79237
+ENV DOTNET_ROOT=/usr/share/dotnet

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,18 +4,21 @@
         "dockerfile": "Dockerfile",
     },
 
-    "extensions": [
-        "ms-dotnettools.csharp",
-        "shardulm94.trailing-spaces",
-        "cake-build.cake-vscode",
-        "streetsidesoftware.code-spell-checker",
-        "hediet.vscode-drawio",
-        "esbenp.prettier-vscode",
-        "yzhang.markdown-all-in-one",
-        "davidanson.vscode-markdownlint",
-        "eamodio.gitlens",
-        "GitHub.vscode-pull-request-github"
-    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csharp",
+                "shardulm94.trailing-spaces",
+                "cake-build.cake-vscode",
+                "streetsidesoftware.code-spell-checker",
+                "hediet.vscode-drawio",
+                "esbenp.prettier-vscode",
+                "yzhang.markdown-all-in-one",
+                "davidanson.vscode-markdownlint",
+                "eamodio.gitlens"
+            ]
+        }
+    },
 
     "remoteUser": "vscode",
 

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '6.0.302'
+  NET_SDK: '6.0.406'
 
 jobs:
   build_main:
@@ -37,7 +37,7 @@ jobs:
       - name: "Generate release notes"
         run: dotnet cake --target=Generate-ReleaseNotes --verbosity=diagnostic
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Build, test and stage"
         run: dotnet cake --target=Stage-Artifacts --configuration=Release --verbosity=diagnostic
@@ -121,7 +121,7 @@ jobs:
       - name: "Publish artifacts"
         run: dotnet cake --target=Push-Artifacts --verbosity=diagnostic
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STABLE_NUGET_FEED_TOKEN: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
           PREVIEW_NUGET_FEED_TOKEN: "az"  # Dummy, auth via below env var
           VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.NUGET_PREVIEW_TOKEN }}"}]}'

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#load "nuget:?package=PleOps.Cake&prerelease"
+#load "nuget:?package=PleOps.Cake&version=0.8.0"
 
 Task("Define-Project")
     .Description("Fill specific project information")

--- a/nuget.config
+++ b/nuget.config
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- This file is only needed if you use preview versions of PleOps.Cake build system -->
+<!-- This file is only needed if you use any other NuGet feed (e.g.: MyGet or Azure Artifacts ) -->
 <configuration>
   <packageSources>
     <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="PleOps-Preview" value="https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/PleOps/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
       <package pattern="*" />
-    </packageSource>
-    <packageSource key="PleOps-Preview">
-      <package pattern="PleOps.Cake" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,14 +4,14 @@
         <PackageVersion Include="Yarhl" Version="3.1.0" />
 
         <PackageVersion Include="nunit" Version="3.13.3" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
-        <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
+        <PackageVersion Include="coverlet.collector" Version="3.2.0" />
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.42.0.51121" />
-        <PackageVersion Include="Roslynator.Analyzers" Version="4.1.1" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.53.0.62665" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="4.2.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description

Update to PleOps.Cake 0.8.0 and Cake 3.0.

- This requires to use a newer Docker image (Ubuntu 22.04) as dependencies need libc >= 2.33.
- Update description of dev containers
- Revert github token workaround
- Update .NET SDK to latest patch version
- Update test dependencies
- Remove unnecessary preview feed.