### PR TITLE
🔧 Refactor workflow into reusable files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,9 @@ root = true
 [*]
 indent_style = space
 
+[*.yml]
+indent_size = 2
+
 [*.md]
 charset = utf-8
 insert_final_newline = true

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -29,8 +29,8 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       dotnet_version: '8.0.100'
-      azure_nuget_feed: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/Example-Preview/nuget/v3/index.json'
+      azure_nuget_feed: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/PleOps/nuget/v3/index.json'
     secrets:
-      #nuget_preview_token: ${{ secrets.NUGET_PREVIEW_TOKEN }}
-      #nuget_stable_token: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
+      nuget_preview_token: "az" # Dummy values as we use Azure DevOps only - Replace with your token for nuget.org
+      nuget_stable_token: "az" # Dummy values as we use Azure DevOps only - Replace with your token for nuget.org
       azure_nuget_token: ${{ secrets.NUGET_PREVIEW_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,114 +13,27 @@ on:
     types:
       - published
 
-env:
-  NET_SDK: '8.0.100'
-
 jobs:
-  build_main:
-    name: "[ubuntu-latest] Build, test and stage"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # We need full history for version number
-
-      - name: "Setup .NET SDK"
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ env.NET_SDK }}
-
-      - name: "Build, test and bundle"
-        run: dotnet run --project build/orchestrator -- --target=CI-Build --configuration=Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Publish artifacts to CI"
-        uses: actions/upload-artifact@v3
-        with:
-          name: "Artifacts"
-          retention-days: 7
-          path: |
-            build/artifacts/
-            !build/artifacts/docs
-
-      - name: Publish docs artifact to CI
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: build/artifacts/docs
-
-  build_sec:
-    name: "[${{ matrix.os }}] Build and test"
+  build:
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # We need full history for version number
-
-      - name: "Setup .NET SDK"
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ env.NET_SDK }}
-
-      # No need to stage as one job can create the binaries for all platforms
-      - name: "Build, test and bundle"
-        run: dotnet run --project build/orchestrator -- --target=Default --configuration=Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    uses: ./.github/workflows/build.yml
+    with:
+      agent_os: ${{ matrix.os }}
+      net_sdk: '8.0.100'
+      is_main_build: ${{ matrix.os == 'ubuntu-latest' }}
 
   # Preview release on push to main only
   # Stable release on version tag push only
-  push_artifacts:
-    name: "Push artifacts"
+  deploy:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-    needs: [ "build_main", "build_sec" ]
-    runs-on: ubuntu-latest
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    env:
-      # Needed only for Azure DevOps Artifacts due to its weird auth method.
-      PREVIEW_NUGET_FEED: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/Example-Preview/nuget/v3/index.json'
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # We need full history for version number
-
-      - name: "Download artifacts"
-        uses: actions/download-artifact@v3
-        with:
-          name: "Artifacts"
-          path: "./build/artifacts/"
-
-      - name: "Setup .NET SDK"
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ env.NET_SDK }}
-
-      # Weird way to authenticate in Azure DevOps Artifacts
-      # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
-      - name: "Install Azure Artifacts Credential Provider"
-        run: wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
-
-      - name: "Deploy artifacts"
-        run: dotnet run --project build/orchestrator -- --target=CI-Deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          STABLE_NUGET_FEED_TOKEN: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
-          PREVIEW_NUGET_FEED_TOKEN: "az"  # Dummy, auth via below env var
-          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.NUGET_PREVIEW_TOKEN }}"}]}'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+    needs: build
+    uses: ./.github/workflows/deploy.yml
+    with:
+      net_sdk: '8.0.100'
+      azure_nuget_feed: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/Example-Preview/nuget/v3/index.json'
+    secrets:
+      #nuget_preview_token: ${{ secrets.NUGET_PREVIEW_TOKEN }}
+      #nuget_stable_token: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
+      azure_nuget_token: ${{ secrets.NUGET_PREVIEW_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -29,8 +29,8 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       dotnet_version: '8.0.100'
-      azure_nuget_feed: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/PleOps/nuget/v3/index.json'
+      azure_nuget_feed: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/Example-Preview/nuget/v3/index.json'
     secrets:
       nuget_preview_token: "az" # Dummy values as we use Azure DevOps only - Replace with your token for nuget.org
       nuget_stable_token: "az" # Dummy values as we use Azure DevOps only - Replace with your token for nuget.org
-      azure_nuget_token: ${{ secrets.NUGET_PREVIEW_TOKEN }}
+      azure_nuget_token: ${{ secrets.AZURE_NUGET_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -18,16 +18,17 @@ jobs:
     name: "Build"
     uses: ./.github/workflows/build.yml
     with:
-      net_sdk: '8.0.100'
+      dotnet_version: '8.0.100'
 
   # Preview release on push to main only
   # Stable release on version tag push only
   deploy:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    name: "Deploy"
+    #TEMP if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     needs: build
     uses: ./.github/workflows/deploy.yml
     with:
-      net_sdk: '8.0.100'
+      dotnet_version: '8.0.100'
       azure_nuget_feed: 'https://pkgs.dev.azure.com/benito356/NetDevOpsTest/_packaging/Example-Preview/nuget/v3/index.json'
     secrets:
       #nuget_preview_token: ${{ secrets.NUGET_PREVIEW_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -24,7 +24,7 @@ jobs:
   # Stable release on version tag push only
   deploy:
     name: "Deploy"
-    #TEMP if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     needs: build
     uses: ./.github/workflows/deploy.yml
     with:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -15,14 +15,10 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    name: "Build"
     uses: ./.github/workflows/build.yml
     with:
-      agent_os: ${{ matrix.os }}
       net_sdk: '8.0.100'
-      is_main_build: ${{ matrix.os == 'ubuntu-latest' }}
 
   # Preview release on push to main only
   # Stable release on version tag push only

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+on:
+  workflow_call:
+    inputs:
+      agent_os:
+        required: true
+        type: string
+      net_sdk:
+        required: true
+        type: string
+      is_main_build:
+        required: true
+        type: boolean
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ${{ inputs.agent_os }}
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # We need full history for version number
+
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.net_sdk }}
+
+      - name: "Build and test"
+        run: dotnet run --project build/orchestrator -- --target=Default --configuration=Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ !inputs.is_main_build }}
+
+      - name: "Build, test and bundle"
+        run: dotnet run --project build/orchestrator -- --target=CI-Build --configuration=Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ inputs.is_main_build }}
+
+      - name: "Publish artifacts to CI"
+        uses: actions/upload-artifact@v3
+        with:
+          name: "Artifacts"
+          retention-days: 7
+          path: |
+            build/artifacts/
+            !build/artifacts/docs
+        if: ${{ inputs.is_main_build }}
+
+      - name: Publish docs artifact to CI
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: build/artifacts/docs
+        if: ${{ inputs.is_main_build }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: "Build"
+run-name: "Build for ${{ inputs.agent_os }}"
 
 on:
   workflow_call:
@@ -14,9 +15,7 @@ on:
         type: boolean
 
 jobs:
-  simple_build:
-    name: "${{ inputs.agent_os }}"
-    if: ${{ !inputs.is_main_build }}
+  build:
     runs-on: ${{ inputs.agent_os }}
     steps:
       - name: "Checkout"
@@ -33,26 +32,13 @@ jobs:
         run: dotnet run --project build/orchestrator -- --target=Default --configuration=Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  full_build:
-    name: "${{ inputs.agent_os }} (Full)"
-    if: ${{ inputs.is_main_build }}
-    runs-on: ${{ inputs.agent_os }}
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # We need full history for version number
-
-      - name: "Setup .NET SDK"
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{ inputs.net_sdk }}
+        if: ${{ !inputs.is_main_build }}
 
       - name: "Build, test and bundle"
         run: dotnet run --project build/orchestrator -- --target=CI-Build --configuration=Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ inputs.is_main_build }}
 
       - name: "Publish artifacts to CI"
         uses: actions/upload-artifact@v3
@@ -62,8 +48,10 @@ jobs:
           path: |
             build/artifacts/
             !build/artifacts/docs
+        if: ${{ inputs.is_main_build }}
 
       - name: Publish docs artifact to CI
         uses: actions/upload-pages-artifact@v2
         with:
           path: build/artifacts/docs
+        if: ${{ inputs.is_main_build }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+name: "Build"
+
 on:
   workflow_call:
     inputs:
@@ -12,8 +14,9 @@ on:
         type: boolean
 
 jobs:
-  build:
-    name: "Build"
+  simple_build:
+    name: "${{ inputs.agent_os }}"
+    if: ${{ !inputs.is_main_build }}
     runs-on: ${{ inputs.agent_os }}
     steps:
       - name: "Checkout"
@@ -30,13 +33,26 @@ jobs:
         run: dotnet run --project build/orchestrator -- --target=Default --configuration=Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !inputs.is_main_build }}
+
+  full_build:
+    name: "${{ inputs.agent_os }} (Full)"
+    if: ${{ inputs.is_main_build }}
+    runs-on: ${{ inputs.agent_os }}
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # We need full history for version number
+
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.net_sdk }}
 
       - name: "Build, test and bundle"
         run: dotnet run --project build/orchestrator -- --target=CI-Build --configuration=Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ inputs.is_main_build }}
 
       - name: "Publish artifacts to CI"
         uses: actions/upload-artifact@v3
@@ -46,10 +62,8 @@ jobs:
           path: |
             build/artifacts/
             !build/artifacts/docs
-        if: ${{ inputs.is_main_build }}
 
       - name: Publish docs artifact to CI
         uses: actions/upload-pages-artifact@v2
         with:
           path: build/artifacts/docs
-        if: ${{ inputs.is_main_build }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: "Build"
 on:
   workflow_call:
     inputs:
-      net_sdk:
+      dotnet_version:
         required: true
         type: string
 
@@ -25,7 +25,7 @@ jobs:
       - name: "Setup .NET SDK"
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ inputs.net_sdk }}
+          dotnet-version: ${{ inputs.dotnet_version }}
 
       - name: "Build and test"
         run: dotnet run --project build/orchestrator -- --target=Default --dotnet-configuration=Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,21 @@
 name: "Build"
-run-name: "Build for ${{ inputs.agent_os }}"
 
 on:
   workflow_call:
     inputs:
-      agent_os:
-        required: true
-        type: string
       net_sdk:
         required: true
         type: string
-      is_main_build:
-        required: true
-        type: boolean
 
 jobs:
   build:
-    runs-on: ${{ inputs.agent_os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    name: "${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    env:
+      is_main_build: ${{ matrix.os == 'ubuntu-latest' }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -29,18 +28,18 @@ jobs:
           dotnet-version: ${{ inputs.net_sdk }}
 
       - name: "Build and test"
-        run: dotnet run --project build/orchestrator -- --target=Default --configuration=Release
+        run: dotnet run --project build/orchestrator -- --target=Default --dotnet-configuration=Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ !inputs.is_main_build }}
 
-      - name: "Build, test and bundle"
-        run: dotnet run --project build/orchestrator -- --target=CI-Build --configuration=Release
+      - name: "Bundle"
+        if: ${{ env.is_main_build }}
+        run: dotnet run --project build/orchestrator -- --target=Bundle --dotnet-configuration=Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ inputs.is_main_build }}
 
       - name: "Publish artifacts to CI"
+        if: ${{ env.is_main_build }}
         uses: actions/upload-artifact@v3
         with:
           name: "Artifacts"
@@ -48,10 +47,9 @@ jobs:
           path: |
             build/artifacts/
             !build/artifacts/docs
-        if: ${{ inputs.is_main_build }}
 
       - name: Publish docs artifact to CI
+        if: ${{ env.is_main_build }}
         uses: actions/upload-pages-artifact@v2
         with:
           path: build/artifacts/docs
-        if: ${{ inputs.is_main_build }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        include:
+          # By default they are no "main build" but if it matches "os" then yes.
+          - os: ubuntu-latest
+            is_main_build: true
     name: "${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    env:
-      is_main_build: ${{ matrix.os == 'ubuntu-latest' }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -33,13 +35,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Bundle"
-        if: ${{ env.is_main_build }}
+        if: ${{ matrix.is_main_build }}
         run: dotnet run --project build/orchestrator -- --target=Bundle --dotnet-configuration=Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Publish artifacts to CI"
-        if: ${{ env.is_main_build }}
+        if: ${{ matrix.is_main_build }}
         uses: actions/upload-artifact@v3
         with:
           name: "Artifacts"
@@ -49,7 +51,7 @@ jobs:
             !build/artifacts/docs
 
       - name: Publish docs artifact to CI
-        if: ${{ env.is_main_build }}
+        if: ${{ matrix.is_main_build }}
         uses: actions/upload-pages-artifact@v2
         with:
           path: build/artifacts/docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+on:
+  workflow_call:
+    inputs:
+      net_sdk:
+        required: true
+        type: string
+      azure_nuget_feed:
+        required: false
+        type: string
+    secrets:
+      nuget_preview_token:
+        required: false
+      nuget_stable_token:
+        required: false
+      azure_nuget_token:
+        required: false
+
+jobs:
+  deploy:
+    name: "Deploy"
+    runs-on: "ubuntu-latest"
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # We need full history for version number
+
+      - name: "Download artifacts"
+        uses: actions/download-artifact@v3
+        with:
+          name: "Artifacts"
+          path: "./build/artifacts/"
+
+      - name: "Setup .NET SDK"
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ inputs.net_sdk }}
+
+      # Weird way to authenticate in Azure DevOps Artifacts
+      # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
+      - name: "Install Azure Artifacts Credential Provider"
+        run: wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
+
+      - name: "Deploy artifacts"
+        run: dotnet run --project build/orchestrator -- --target=CI-Deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_NUGET_FEED_TOKEN: ${{ secrets.nuget_stable_token }}
+          PREVIEW_NUGET_FEED_TOKEN: ${{ secrets.nuget_preview_token }}
+          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ inputs.azure_nuget_feed }}", "username":"", "password":"${{ secrets.azure_nuget_token }}"}]}'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         run: wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
 
       - name: "Deploy artifacts"
-        run: dotnet run --project build/orchestrator -- --target=CI-Deploy
+        run: dotnet run --project build/orchestrator -- --target=Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STABLE_NUGET_FEED_TOKEN: ${{ secrets.nuget_stable_token }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,5 @@
+name: "Deploy"
+
 on:
   workflow_call:
     inputs:
@@ -16,10 +18,9 @@ on:
         required: false
 
 jobs:
-  deploy:
-    name: "Deploy"
+  upload_doc:
+    name: "Docs to GitHub Page"
     runs-on: "ubuntu-latest"
-
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write      # to deploy to Pages
@@ -28,7 +29,14 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
 
+  push_artifacts:
+    name: "Upload artifacts"
+    runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -58,7 +66,3 @@ jobs:
           STABLE_NUGET_FEED_TOKEN: ${{ secrets.nuget_stable_token }}
           PREVIEW_NUGET_FEED_TOKEN: ${{ secrets.nuget_preview_token }}
           VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ inputs.azure_nuget_feed }}", "username":"", "password":"${{ secrets.azure_nuget_token }}"}]}'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: "Deploy"
 on:
   workflow_call:
     inputs:
-      net_sdk:
+      dotnet_version:
         required: true
         type: string
       azure_nuget_feed:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   upload_doc:
-    name: "Docs to GitHub Page"
+    name: "Documentation"
     runs-on: "ubuntu-latest"
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
@@ -35,7 +35,7 @@ jobs:
         uses: actions/deploy-pages@v2
 
   push_artifacts:
-    name: "Upload artifacts"
+    name: "Artifacts"
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
@@ -52,7 +52,7 @@ jobs:
       - name: "Setup .NET SDK"
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ inputs.net_sdk }}
+          dotnet-version: ${{ inputs.dotnet_version }}
 
       # Weird way to authenticate in Azure DevOps Artifacts
       # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Tech stack:
 | Release | Package                                                           |
 | ------- | ----------------------------------------------------------------- |
 | Stable  | [![Azure Artifacts](https://feeds.dev.azure.com/benito356/339c91a8-9d6c-4082-8b1a-93c2ae76b637/_apis/public/Packaging/Feeds/e3acf8ba-ec70-46f0-b1a5-da1ce3dd5d9f/Packages/b8696a32-e71a-4479-9b0e-002997b8d8ef/Badge)](https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=package&feed=e3acf8ba-ec70-46f0-b1a5-da1ce3dd5d9f&package=b8696a32-e71a-4479-9b0e-002997b8d8ef&preferRelease=true) |
-| Preview | [Azure Artifacts](https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps) |
+| Preview | [Azure Artifacts](https://dev.azure.com/benito356/NetDevOpsTest/_artifacts/feed/Example-Preview) |
 
 ## Setup
 
 Follow the
-[checklist in PleOps.Cake](https://www.pleonex.dev/PleOps.Cake/docs/getting-started/project-setup.html)
+[getting started guide from PleOps.Cake](https://www.pleonex.dev/PleOps.Cake/docs/getting-started/tutorial.html)
 to adapt this template to your project.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tech stack:
 | Release | Package                                                           |
 | ------- | ----------------------------------------------------------------- |
 | Stable  | [![Azure Artifacts](https://feeds.dev.azure.com/benito356/339c91a8-9d6c-4082-8b1a-93c2ae76b637/_apis/public/Packaging/Feeds/e3acf8ba-ec70-46f0-b1a5-da1ce3dd5d9f/Packages/b8696a32-e71a-4479-9b0e-002997b8d8ef/Badge)](https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=package&feed=e3acf8ba-ec70-46f0-b1a5-da1ce3dd5d9f&package=b8696a32-e71a-4479-9b0e-002997b8d8ef&preferRelease=true) |
-| Preview | [Azure Artifacts](https://dev.azure.com/SceneGate/SceneGate/_packaging?_a=feed&feed=SceneGate-Preview) |
+| Preview | [Azure Artifacts](https://dev.azure.com/benito356/NetDevOpsTest/_packaging?_a=feed&feed=PleOps) |
 
 ## Setup
 
@@ -37,10 +37,12 @@ The project requires to build .NET 8.0 SDK.
 To build, test and generate artifacts run:
 
 ```sh
-dotnet run --project build/orchestrator -- --target=CI-Build
-```
+# Build and run tests
+dotnet run --project build/orchestrator
 
-For a quick build use the `Default` target or skip the `target` argument.
+# (Optional) Create bundles (nuget, zips, docs)
+dotnet run --project build/orchestrator -- --target=Bundle
+```
 
 ## Release
 

--- a/build/orchestrator/BuildSystem.csproj
+++ b/build/orchestrator/BuildSystem.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting.PleOps.Recipe" Version="0.9.0-preview.53" />
+    <PackageReference Include="Cake.Frosting.PleOps.Recipe" Version="0.9.0-preview.59" />
   </ItemGroup>
 
 </Project>

--- a/build/orchestrator/Program.cs
+++ b/build/orchestrator/Program.cs
@@ -51,7 +51,6 @@ public sealed class DefaultTask : FrostingTask
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.BundleNuGetsTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.BundleApplicationsTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.BuildTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.BundleTask))]
 public sealed class BundleTask : FrostingTask
 {
 }

--- a/build/orchestrator/Program.cs
+++ b/build/orchestrator/Program.cs
@@ -38,26 +38,28 @@ public sealed class BuildLifetime : FrostingLifetime<PleOpsBuildContext>
 
 [TaskName("Default")]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.CleanArtifactsTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.BuildTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.TestTask))]
 public sealed class DefaultTask : FrostingTask
 {
 }
 
-[TaskName("CI-Build")]
+[TaskName("Bundle")]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.CleanArtifactsTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.GitHub.ExportReleaseNotesTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.PrepareProjectBundlesTask))]
-[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.DocFxTasks.PrepareProjectBundlesTask))]
-public sealed class CIBuildTask : FrostingTask
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.BundleNuGetsTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.BundleApplicationsTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.BuildTask))]
+[IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.DocFx.BundleTask))]
+public sealed class BundleTask : FrostingTask
 {
 }
 
-[TaskName("CI-Deploy")]
+[TaskName("Deploy")]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Common.SetGitVersionTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.Dotnet.DotnetTasks.DeployProjectTask))]
 [IsDependentOn(typeof(Cake.Frosting.PleOps.Recipe.GitHub.UploadReleaseBinariesTask))]
-public sealed class CIDeployTask : FrostingTask
+public sealed class DeployTask : FrostingTask
 {
 }


### PR DESCRIPTION
Refactor the CI workflow into reusable workflows. The goal is to reduce the size and complexity of the files. It also helps to make them easier to configure via generic variables.
Related to https://github.com/pleonex/PleOps.Cake/pull/72

- [x] Related code has been tested automatically or manually
- [x] Related documentation is updated
- [x] I acknowledge I have read and filled this checklist and accept the
      [developer certificate of origin](https://developercertificate.org/)

## Acceptance criteria

- The build diagram has one block with three items for building in different platform. It doesn't have two separate blocks
- There is one block for deploy (same prod or preview)

### Follow-up work

None.

### Example

See CI output
